### PR TITLE
Dockerize kweb

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -6,4 +6,4 @@ COPY --chown=jovyan . kweb
 WORKDIR kweb
 RUN make install
 WORKDIR src/kweb
-ENTRYPOINT ["make", "run"]
+ENTRYPOINT ["uvicorn", "main:app", "--host 0.0.0.0"]

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,9 @@
+FROM joamatab/gdsfactory:latest
+
+EXPOSE 8000
+
+COPY --chown=jovyan . kweb
+WORKDIR kweb
+RUN make install
+WORKDIR src/kweb
+ENTRYPOINT ["make", "run"]

--- a/dockerfile
+++ b/dockerfile
@@ -6,4 +6,4 @@ COPY --chown=jovyan . kweb
 WORKDIR kweb
 RUN make install
 WORKDIR src/kweb
-ENTRYPOINT ["uvicorn", "main:app", "--host 0.0.0.0"]
+ENTRYPOINT ["uvicorn", "main:app", "--host", "0.0.0.0"]

--- a/src/kweb/Makefile
+++ b/src/kweb/Makefile
@@ -1,2 +1,2 @@
 run:
-	uvicorn main:app --reload
+	uvicorn main:app --reload --host 0.0.0.0

--- a/src/kweb/Makefile
+++ b/src/kweb/Makefile
@@ -1,2 +1,2 @@
 run:
-	uvicorn main:app --reload --host 0.0.0.0
+	uvicorn main:app --reload


### PR DESCRIPTION
@sebastian-goeldi @joamatab,
with regard to our discussion in the las developer meeting:
![Docker Port Forward](https://user-images.githubusercontent.com/92856893/233851097-72743fb1-6888-4263-9aeb-d9d9af7d76c2.PNG)
It seems to work just fine to run kweb inside a docker container and stream the gds out over websocket to the host computer. It actually also works on codespaces, and even on docker containers inside codespaces (container in container) as seen in the screenshot.
Or did I misunderstand you during the meeting @sebastian-goeldi?
Regards JD