### PR TITLE
feat: enhance web viewer with layer presets, measurements and notes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,1 @@
+{"python.defaultInterpreterPath":"python"}

--- a/src/kweb/static/client.css
+++ b/src/kweb/static/client.css
@@ -132,3 +132,78 @@ ul, #myUL {
   width: 80%;
   height: 80%;
 }
+
+.layer-controls .btn,
+.layer-controls .form-control,
+.layer-controls .form-select,
+.layer-controls .input-group-text {
+  font-size: 0.75rem;
+}
+
+.layer-hidden {
+  opacity: 0.4;
+}
+
+.layer-filter-hidden {
+  display: none !important;
+}
+
+#measurement-overlay .measurement-box {
+  background: rgba(0, 0, 0, 0.72);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  color: #f8f9fa;
+  backdrop-filter: blur(4px);
+  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.35);
+}
+
+#measurement-overlay .measurement-summary {
+  font-weight: 500;
+}
+
+#measurement-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: 10rem;
+  overflow-y: auto;
+}
+
+#measurement-list .measurement-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 0.35rem;
+}
+
+#measurement-list .measurement-row:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+#measurement-list .measurement-values {
+  font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.75rem;
+}
+
+#note-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  max-height: 8rem;
+  overflow-y: auto;
+  margin-top: 0.5rem;
+}
+
+#note-list .note-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 0.35rem;
+}
+
+#note-list .note-row:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+#note-list .note-values {
+  font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-size: 0.75rem;
+}

--- a/src/kweb/static/viewer.js
+++ b/src/kweb/static/viewer.js
@@ -612,7 +612,7 @@ function setVisibilityRecursively(layers, visible) {
   layers.forEach((layer) => {
     layer.v = visible;
     updateLayerVisibilityClassById(layer.id, visible);
-    if (layer.children) {
+    if (Array.isArray(layer.children) && layer.children.length > 0) {
       setVisibilityRecursively(layer.children, visible);
     }
   });
@@ -898,9 +898,32 @@ function csvNumber(value) {
   return value.toFixed(6);
 }
 
+const messages = {
+  en: {
+    annotationPrompt: "Note (the last cursor position will be used)",
+  },
+  es: {
+    annotationPrompt: "Nota (se usará la última posición del cursor)",
+  },
+};
+
+function getUserLanguage() {
+  return navigator.language?.slice(0, 2) || "en";
+}
+
+function getMessage(key) {
+  const lang = getUserLanguage();
+  if (messages[lang]?.[key]) {
+    return messages[lang][key];
+  }
+  if (messages.en?.[key]) {
+    return messages.en[key];
+  }
+  return "";
+}
+
 function getPointerCoordinates() {
-  let x = lastPointer.x;
-  let y = lastPointer.y;
+  let { x, y } = lastPointer;
   if (!Number.isFinite(x) || !Number.isFinite(y)) {
     x = canvas ? canvas.clientWidth / 2 : 0;
     y = canvas ? canvas.clientHeight / 2 : 0;
@@ -912,7 +935,7 @@ function openAnnotationDialog() {
   if (!canvas || !socket || socket.readyState !== WebSocket.OPEN) {
     return;
   }
-  const text = prompt("Nota (se usará la última posición del cursor)", "");
+  const text = prompt(getMessage("annotationPrompt"), "");
   if (text === null) {
     return;
   }

--- a/src/kweb/templates/viewer.html
+++ b/src/kweb/templates/viewer.html
@@ -9,6 +9,7 @@
         <link rel="stylesheet" href={{ url_for("kweb_static", path="/bootstrap/bootstrap.min.css") }}>
     </link>
     <link rel="stylesheet" href={{ url_for("kweb_static", path="/custom.css") }}>
+    <link rel="stylesheet" href={{ url_for("kweb_static", path="/client.css") }}>
     <script type="text/javascript" src={{ url_for("kweb_static", path="/bootstrap/bootstrap.bundle.min.js") }}></script>
 </link>
 <link rel="icon" type="image/png" href={{ url_for("kweb_static", path="img/kweb.png") }}>
@@ -26,6 +27,31 @@
                      id="floating-buttons">
                     <div id="modes" class="col m-0"></div>
                     <div id="menu" class="col m-0 px-2 text-end"></div>
+                    <div id="measurement-overlay"
+                         class="col-12 mt-3 measurement-overlay d-none">
+                        <div class="measurement-box">
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                <span class="fw-semibold">Annotations</span>
+                                <div class="btn-group btn-group-sm" role="group">
+                                    <button class="btn btn-outline-light"
+                                            type="button"
+                                            id="measurement-export">Export Rulers</button>
+                                </div>
+                            </div>
+                            <div id="measurement-section" class="mb-2">
+                                <div id="measurement-summary"
+                                     class="measurement-summary small text-secondary mb-1"></div>
+                                <div id="measurement-list"
+                                     class="measurement-list small"></div>
+                            </div>
+                            <div id="note-section" class="note-section">
+                                <div id="note-summary"
+                                     class="note-summary small text-secondary mb-1"></div>
+                                <div id="note-list"
+                                     class="note-list small"></div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div id="rightpanel"
@@ -89,6 +115,41 @@
                                        id="layerEmptySwitch"
                                        checked>
                                 <label class="form-check-label ps-2" for="layerEmptySwitch">Hide Empty Layers</label>
+                            </div>
+                            <div class="p-2 pt-0 layer-controls">
+                                <div class="input-group input-group-sm mb-2">
+                                    <span class="input-group-text">Filter</span>
+                                    <input type="text"
+                                           class="form-control"
+                                           id="layerSearchInput"
+                                           placeholder="Layer name...">
+                                    <button class="btn btn-outline-secondary"
+                                            type="button"
+                                            id="layerClearSearch">Clear</button>
+                                </div>
+                                <div class="btn-group btn-group-sm w-100 mb-2"
+                                     role="group"
+                                     aria-label="Visibility shortcuts">
+                                    <button class="btn btn-outline-light"
+                                            type="button"
+                                            id="layerShowAll">Show all</button>
+                                    <button class="btn btn-outline-light"
+                                            type="button"
+                                            id="layerHideAll">Hide all</button>
+                                </div>
+                                <div class="input-group input-group-sm">
+                                    <span class="input-group-text">Presets</span>
+                                    <select class="form-select"
+                                            id="layerPresetSelect">
+                                            <option value="" selected>Select preset</option>
+                                    </select>
+                                    <button class="btn btn-outline-primary"
+                                            type="button"
+                                            id="layerSavePreset">Save</button>
+                                    <button class="btn btn-outline-danger"
+                                            type="button"
+                                            id="layerDeletePreset">Delete</button>
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
- Added layer panel enhancements: text filter, show/hide all, persistent presets stored in localStorage, and state synchronization with KLayout.
 
- Introduced real-time measurement panel with length/Δx/Δy/angle, ruler export to CSV, and automatic updates from backend events.

- Implemented quick annotations workflow: “Add Note” prompt tied to last cursor position, notes persisted via WebSocket, and unified overlay displaying both rulers and notes.

<img width="1799" height="1008" alt="Captura de pantalla 2025-11-13 a la(s) 8 36 25 p  m" src="https://github.com/user-attachments/assets/b4d5ed19-0c9d-4bc8-9a8d-d3d6d7e976b0" />

## Summary by Sourcery

Enhance the web viewer by extending the layer panel with search, visibility controls, and persistent presets; introduce a real-time measurement and notes overlay with CSV export; and add a quick annotations workflow tied to cursor position and synchronized with the backend.

New Features:
- Add layer panel search, show/hide all buttons, and user-defined presets stored in localStorage
- Introduce measurement overlay displaying length, Δx, Δy, and angle with live updates and CSV export
- Implement quick note annotations at the last cursor position with WebSocket persistence and unified overlay for rulers and notes

Enhancements:
- Synchronize layer and annotation state bidirectionally with the KLayout backend